### PR TITLE
Remove baker.multipleTextureSets

### DIFF
--- a/utils/marmoset.py
+++ b/utils/marmoset.py
@@ -51,7 +51,6 @@ def create_baker(properties: dict):
     baker.ignoreTransforms = False
     baker.smoothCage = True
     baker.ignoreBackfaces = True
-    baker.multipleTextureSets = False
     baker.outputWidth = properties['resolution_x']
     baker.outputHeight = properties['resolution_y']
     # NOTE: Output samples is broken in older APIs


### PR DESCRIPTION
multipleTextureSets has been removed from Marmoset Toolbag 5
https://marmoset.co/python/reference5.html#BakerObject

If included, this line throws the following Traceback in Marmoset 5 logs:
```
Traceback (most recent call last):
  File "<string>", line 159, in <module>
  File "<string>", line 131, in main
  File "<string>", line 54, in create_baker
AttributeError: 'mset.BakerObject' object has no attribute 'multipleTextureSets'
```